### PR TITLE
Issue 209 cpu timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Build
 .idea
 doxgen_generated
 *.so
+common

--- a/ov_core/src/track/Grider_FAST.h
+++ b/ov_core/src/track/Grider_FAST.h
@@ -96,10 +96,12 @@ namespace ov_core {
             int ct_rows = std::floor(img.rows/size_y);
             std::vector<std::vector<cv::KeyPoint>> collection(ct_cols*ct_rows);
             parallel_for_(cv::Range(0, ct_cols*ct_rows), [&](const cv::Range& range) {
-				// PRINT_RECORD_FOR_THIS_BLOCK("slam2 par_for");
 				// We time this by timing OpenCV's parallel_for_
 
                 for (int r = range.start; r < range.end; r++) {
+#ifdef ILLIXR_INTEGRATION
+					CPU_TIMER_TIME_FUNCTION();
+#endif /// ILLIXR_INTEGRATION
                     // Calculate what cell xy value we are in
                     int x = r%ct_cols*size_x;
                     int y = r/ct_cols*size_y;

--- a/ov_core/src/track/Grider_FAST.h
+++ b/ov_core/src/track/Grider_FAST.h
@@ -96,12 +96,11 @@ namespace ov_core {
             int ct_rows = std::floor(img.rows/size_y);
             std::vector<std::vector<cv::KeyPoint>> collection(ct_cols*ct_rows);
             parallel_for_(cv::Range(0, ct_cols*ct_rows), [&](const cv::Range& range) {
-				// We time this by timing OpenCV's parallel_for_
+#ifdef ILLIXR_INTEGRATION
+				CPU_TIMER_TIME_BLOCK("perform_griding");
+#endif /// ILLIXR_INTEGRATION
 
                 for (int r = range.start; r < range.end; r++) {
-#ifdef ILLIXR_INTEGRATION
-					CPU_TIMER_TIME_FUNCTION();
-#endif /// ILLIXR_INTEGRATION
                     // Calculate what cell xy value we are in
                     int x = r%ct_cols*size_x;
                     int y = r/ct_cols*size_y;

--- a/ov_core/src/track/TrackKLT.cpp
+++ b/ov_core/src/track/TrackKLT.cpp
@@ -143,37 +143,51 @@ void TrackKLT::feed_stereo(double timestamp, cv::Mat &img_leftin, cv::Mat &img_r
     std::unique_lock<std::mutex> lck2(mtx_feeds.at(cam_id_right));
 
     cv::Mat img_left, img_right;
+    std::vector<cv::Mat> imgpyr_left, imgpyr_right;
+
 #ifdef ILLIXR_INTEGRATION
-    // Histogram equalize
-    std::thread t_lhe = timed_thread("slam2 hist l", cv::equalizeHist, cv::_InputArray(img_leftin ), cv::_OutputArray(img_left ));
-    std::thread t_rhe = timed_thread("slam2 hist r", cv::equalizeHist, cv::_InputArray(img_rightin), cv::_OutputArray(img_right));
+	parallel_for_(cv::Range(0, 2), [&](const cv::Range& range){
+		for (int i = range.start; i < range.end; i++) {
+			CPU_TIMER_TIME_BLOCK("hist_and_optical_flow")
+
+			// Histogram equalize
+			cv::equalizeHist(
+				cv::_InputArray (i == 0 ? img_leftin : img_rightin),
+				i == 0 ? img_left : img_right
+			);
+
+			// Extract image pyramids (boost seems to require us to put all the arguments even if there are defaults....)
+			cv::buildOpticalFlowPyramid(
+				i == 0 ? img_left : img_right,
+				cv::_OutputArray(i == 0 ? imgpyr_left : imgpyr_right),
+				win_size,
+				pyr_levels,
+				false,
+				cv::BORDER_REFLECT_101,
+				cv::BORDER_CONSTANT,
+				true
+			);
+		}
+	});
 #else /// ILLIXR_INTEGRATION
+    // Histogram equalize
     boost::thread t_lhe = boost::thread(cv::equalizeHist, boost::cref(img_leftin), boost::ref(img_left));
     boost::thread t_rhe = boost::thread(cv::equalizeHist, boost::cref(img_rightin), boost::ref(img_right));
-#endif /// ILLIXR_INTEGRATION
+
     t_lhe.join();
     t_rhe.join();
 
     // Extract image pyramids (boost seems to require us to put all the arguments even if there are defaults....)
-    std::vector<cv::Mat> imgpyr_left, imgpyr_right;
-#ifdef ILLIXR_INTEGRATION
-    std::thread t_lp = timed_thread("slam2 pyramid l", &cv::buildOpticalFlowPyramid, cv::_InputArray(img_left),
-                                       cv::_OutputArray(imgpyr_left), win_size, pyr_levels, false,
-                                       cv::BORDER_REFLECT_101, cv::BORDER_CONSTANT, true);
-    std::thread t_rp = timed_thread("slam2 pyramid r", &cv::buildOpticalFlowPyramid, cv::_InputArray(img_right),
-                                       cv::_OutputArray(imgpyr_right), win_size, pyr_levels,
-                                       false, cv::BORDER_REFLECT_101, cv::BORDER_CONSTANT, true);
-#else /// ILLIXR_INTEGRATION
     boost::thread t_lp = boost::thread(cv::buildOpticalFlowPyramid, boost::cref(img_left),
                                        boost::ref(imgpyr_left), boost::ref(win_size), boost::ref(pyr_levels), false,
                                        cv::BORDER_REFLECT_101, cv::BORDER_CONSTANT, true);
     boost::thread t_rp = boost::thread(cv::buildOpticalFlowPyramid, boost::cref(img_right),
                                        boost::ref(imgpyr_right), boost::ref(win_size), boost::ref(pyr_levels),
                                        false, cv::BORDER_REFLECT_101, cv::BORDER_CONSTANT, true);
-#endif /// ILLIXR_INTEGRATION
+
     t_lp.join();
     t_rp.join();
-
+#endif /// ILLIXR_INTEGRATION
     rT2 =  boost::posix_time::microsec_clock::local_time();
 
     // If we didn't have any successful tracks last time, just extract this time
@@ -207,20 +221,30 @@ void TrackKLT::feed_stereo(double timestamp, cv::Mat &img_leftin, cv::Mat &img_r
 
     // Lets track temporally
 #ifdef ILLIXR_INTEGRATION
-    std::thread t_ll = timed_thread("slam2 matching l", &TrackKLT::perform_matching, this, boost::cref(img_pyramid_last[cam_id_left]), boost::cref(imgpyr_left),
-                                       boost::ref(pts_last[cam_id_left]), boost::ref(pts_left_new), cam_id_left, cam_id_left, boost::ref(mask_ll));
-    std::thread t_rr = timed_thread("slam2 matching r", &TrackKLT::perform_matching, this, boost::cref(img_pyramid_last[cam_id_right]), boost::cref(imgpyr_right),
-                                       boost::ref(pts_last[cam_id_right]), boost::ref(pts_right_new), cam_id_right, cam_id_right, boost::ref(mask_rr));
+	parallel_for_(cv::Range(0, 2), [&](const cv::Range& range){
+		for (int i = range.start; i < range.end; i++) {
+			CPU_TIMER_TIME_BLOCK("perform_matching");
+			perform_matching(
+				img_pyramid_last[i == 0 ? cam_id_left : cam_id_right],
+				i == 0 ? imgpyr_left : imgpyr_right,
+				pts_last[i == 0 ? cam_id_left : cam_id_right],
+				i == 0 ? pts_left_new : pts_right_new,
+				i == 0 ? cam_id_left : cam_id_right,
+				i == 0 ? cam_id_left : cam_id_right,
+				i == 0 ? mask_ll : mask_rr
+			);
+		}
+	});
 #else /// ILLIXR_INTEGRATION
     boost::thread t_ll = boost::thread(&TrackKLT::perform_matching, this, boost::cref(img_pyramid_last[cam_id_left]), boost::cref(imgpyr_left),
                                        boost::ref(pts_last[cam_id_left]), boost::ref(pts_left_new), cam_id_left, cam_id_left, boost::ref(mask_ll));
     boost::thread t_rr = boost::thread(&TrackKLT::perform_matching, this, boost::cref(img_pyramid_last[cam_id_right]), boost::cref(imgpyr_right),
                                        boost::ref(pts_last[cam_id_right]), boost::ref(pts_right_new), cam_id_right, cam_id_right, boost::ref(mask_rr));
-#endif /// ILLIXR_INTEGRATION
 
     // Wait till both threads finish
     t_ll.join();
     t_rr.join();
+#endif /// ILLIXR_INTEGRATION
 
     rT4 =  boost::posix_time::microsec_clock::local_time();
 

--- a/ov_msckf/src/core/VioManager.cpp
+++ b/ov_msckf/src/core/VioManager.cpp
@@ -611,7 +611,7 @@ void VioManager::do_feature_propagate_update(double timestamp) {
 #ifndef NDEBUG
     // Debug for camera imu offset
     if(state->_options.do_calib_camera_timeoffset) {
-        printf("camera-imu timeoffset = %.5f\n",state->_calib_dt_CAMtoIMU->value()(0));
+        // printf("camera-imu timeoffset = %.5f\n",state->_calib_dt_CAMtoIMU->value()(0));
     }
 #endif
 
@@ -620,9 +620,9 @@ void VioManager::do_feature_propagate_update(double timestamp) {
     if(state->_options.do_calib_camera_intrinsics) {
         for(int i=0; i<state->_options.num_cameras; i++) {
             Vec* calib = state->_cam_intrinsics.at(i);
-            printf("cam%d intrinsics = %.3f,%.3f,%.3f,%.3f | %.3f,%.3f,%.3f,%.3f\n",(int)i,
-                     calib->value()(0),calib->value()(1),calib->value()(2),calib->value()(3),
-                     calib->value()(4),calib->value()(5),calib->value()(6),calib->value()(7));
+            // printf("cam%d intrinsics = %.3f,%.3f,%.3f,%.3f | %.3f,%.3f,%.3f,%.3f\n",(int)i,
+            //          calib->value()(0),calib->value()(1),calib->value()(2),calib->value()(3),
+            //          calib->value()(4),calib->value()(5),calib->value()(6),calib->value()(7));
         }
     }
 #endif
@@ -632,9 +632,9 @@ void VioManager::do_feature_propagate_update(double timestamp) {
     if(state->_options.do_calib_camera_pose) {
         for(int i=0; i<state->_options.num_cameras; i++) {
             PoseJPL* calib = state->_calib_IMUtoCAM.at(i);
-            printf("cam%d extrinsics = %.3f,%.3f,%.3f,%.3f | %.3f,%.3f,%.3f\n",(int)i,
-                     calib->quat()(0),calib->quat()(1),calib->quat()(2),calib->quat()(3),
-                     calib->pos()(0),calib->pos()(1),calib->pos()(2));
+            // printf("cam%d extrinsics = %.3f,%.3f,%.3f,%.3f | %.3f,%.3f,%.3f\n",(int)i,
+            //          calib->quat()(0),calib->quat()(1),calib->quat()(2),calib->quat()(3),
+            //          calib->pos()(0),calib->pos()(1),calib->pos()(2));
         }
     }
 #endif

--- a/ov_msckf/src/core/VioManager.cpp
+++ b/ov_msckf/src/core/VioManager.cpp
@@ -611,7 +611,7 @@ void VioManager::do_feature_propagate_update(double timestamp) {
 #ifndef NDEBUG
     // Debug for camera imu offset
     if(state->_options.do_calib_camera_timeoffset) {
-        // printf("camera-imu timeoffset = %.5f\n",state->_calib_dt_CAMtoIMU->value()(0));
+        printf("camera-imu timeoffset = %.5f\n",state->_calib_dt_CAMtoIMU->value()(0));
     }
 #endif
 
@@ -620,9 +620,9 @@ void VioManager::do_feature_propagate_update(double timestamp) {
     if(state->_options.do_calib_camera_intrinsics) {
         for(int i=0; i<state->_options.num_cameras; i++) {
             Vec* calib = state->_cam_intrinsics.at(i);
-            // printf("cam%d intrinsics = %.3f,%.3f,%.3f,%.3f | %.3f,%.3f,%.3f,%.3f\n",(int)i,
-            //          calib->value()(0),calib->value()(1),calib->value()(2),calib->value()(3),
-            //          calib->value()(4),calib->value()(5),calib->value()(6),calib->value()(7));
+            printf("cam%d intrinsics = %.3f,%.3f,%.3f,%.3f | %.3f,%.3f,%.3f,%.3f\n",(int)i,
+                     calib->value()(0),calib->value()(1),calib->value()(2),calib->value()(3),
+                     calib->value()(4),calib->value()(5),calib->value()(6),calib->value()(7));
         }
     }
 #endif
@@ -632,9 +632,9 @@ void VioManager::do_feature_propagate_update(double timestamp) {
     if(state->_options.do_calib_camera_pose) {
         for(int i=0; i<state->_options.num_cameras; i++) {
             PoseJPL* calib = state->_calib_IMUtoCAM.at(i);
-            // printf("cam%d extrinsics = %.3f,%.3f,%.3f,%.3f | %.3f,%.3f,%.3f\n",(int)i,
-            //          calib->quat()(0),calib->quat()(1),calib->quat()(2),calib->quat()(3),
-            //          calib->pos()(0),calib->pos()(1),calib->pos()(2));
+            printf("cam%d extrinsics = %.3f,%.3f,%.3f,%.3f | %.3f,%.3f,%.3f\n",(int)i,
+                     calib->quat()(0),calib->quat()(1),calib->quat()(2),calib->quat()(3),
+                     calib->pos()(0),calib->pos()(1),calib->pos()(2));
         }
     }
 #endif

--- a/ov_msckf/src/slam2.cpp
+++ b/ov_msckf/src/slam2.cpp
@@ -186,7 +186,7 @@ public:
 		, open_vins_estimator{manager_params}
 		, imu_cam_buffer{nullptr}
 	{
-		sb->schedule<imu_cam_type>(id, "imu_cam", [&](switchboard::ptr<const imu_cam_type> datum, std::size_t iteration_no) {
+		sb->schedule<imu_cam_type>(get_name(), "imu_cam", [&](switchboard::ptr<const imu_cam_type> datum, std::size_t iteration_no) {
 			this->feed_imu_cam(datum, iteration_no);
 		});
 	}

--- a/ov_msckf/src/slam2.cpp
+++ b/ov_msckf/src/slam2.cpp
@@ -183,40 +183,19 @@ public:
 		, sb{pb->lookup_impl<switchboard>()}
 		, _m_pose{sb->get_writer<pose_type>("slow_pose")}
 		, _m_imu_integrator_input{sb->get_writer<imu_integrator_input>("imu_integrator_input")}
-		, _m_begin{std::chrono::system_clock::now()}
 		, open_vins_estimator{manager_params}
 		, imu_cam_buffer{nullptr}
 	{
-		_m_pose.put(_m_pose.allocate(
-			std::chrono::time_point<std::chrono::system_clock>{},
-			Eigen::Vector3f{0, 0, 0},
-			Eigen::Quaternionf{1, 0, 0, 0}
-		));
-
-        // Disabling OpenCV threading is faster on x86 desktop but slower on
-        // jetson. Keeping this here for manual disabling.
-        // cv::setNumThreads(0);
-
-#ifdef CV_HAS_METRICS
-		cv::metrics::setAccount(new std::string{"-1"});
-#endif
-
-	}
-
-
-	virtual void start() override {
-		plugin::start();
 		sb->schedule<imu_cam_type>(id, "imu_cam", [&](switchboard::ptr<const imu_cam_type> datum, std::size_t iteration_no) {
 			this->feed_imu_cam(datum, iteration_no);
 		});
 	}
 
-
 	void feed_imu_cam(switchboard::ptr<const imu_cam_type> datum, std::size_t iteration_no) {
 		// Ensures that slam doesnt start before valid IMU readings come in
-		if (datum == NULL) {
-			assert(previous_timestamp == 0);
-			return;
+		if (datum == nullptr) {
+			std::cerr << "slam2:feed_imu_cam datum == nullptr\n";
+			abort();
 		}
 
 		// This ensures that every data point is coming in chronological order If youre failing this assert, 
@@ -241,14 +220,6 @@ public:
 			return;
 		}
 
-#ifdef CV_HAS_METRICS
-		cv::metrics::setAccount(new std::string{std::to_string(iteration_no)});
-		if (iteration_no % 20 == 0) {
-			cv::metrics::dump();
-		}
-#else
-#warning "No OpenCV metrics available. Please recompile OpenCV from git clone --branch 3.4.6-instrumented https://github.com/ILLIXR/opencv/. (see install_deps.sh)"
-#endif
 
 		cv::Mat img0{imu_cam_buffer->img0.value()};
 		cv::Mat img1{imu_cam_buffer->img1.value()};
@@ -319,8 +290,8 @@ public:
 private:
 	const std::shared_ptr<switchboard> sb;
 	switchboard::writer<pose_type> _m_pose;
-    switchboard::writer<imu_integrator_input> _m_imu_integrator_input;
-	time_type _m_begin;
+	switchboard::writer<imu_integrator_input> _m_imu_integrator_input;
+
 	State *state;
 
 	VioManagerOptions manager_params = create_params();

--- a/ov_msckf/src/slam2.cpp
+++ b/ov_msckf/src/slam2.cpp
@@ -220,11 +220,16 @@ public:
 			return;
 		}
 
-
-		cv::Mat img0{imu_cam_buffer->img0.value()};
-		cv::Mat img1{imu_cam_buffer->img1.value()};
+		{
+			CPU_TIMER_TIME_BLOCK("cv::Mat copy");
+			cv::Mat img0{imu_cam_buffer->img0.value()};
+			cv::Mat img1{imu_cam_buffer->img1.value()};
+		}
 		double buffer_timestamp_seconds = double(imu_cam_buffer->dataset_time) / NANO_SEC;
-		open_vins_estimator.feed_measurement_stereo(buffer_timestamp_seconds, img0, img1, 0, 1);
+		{
+			CPU_TIMER_TIME_BLOCK("feed_measurement_stereo");
+			open_vins_estimator.feed_measurement_stereo(buffer_timestamp_seconds, img0, img1, 0, 1);
+		}
 
 		// Get the pose returned from SLAM
 		state = open_vins_estimator.get_state();
@@ -245,6 +250,8 @@ public:
         assert(isfinite(swapped_pos[2]));
 
 		if (open_vins_estimator.initialized()) {
+			CPU_TIMER_TIME_BLOCK("publish");
+
 			if (isUninitialized) {
 				isUninitialized = false;
 			}

--- a/ov_msckf/src/slam2.cpp
+++ b/ov_msckf/src/slam2.cpp
@@ -220,14 +220,21 @@ public:
 			return;
 		}
 
+		cv::Mat img0;
+		cv::Mat img1;
+
 		{
+#ifdef ILLIXR_INTEGRATION
 			CPU_TIMER_TIME_BLOCK("cv::Mat copy");
-			cv::Mat img0{imu_cam_buffer->img0.value()};
-			cv::Mat img1{imu_cam_buffer->img1.value()};
+#endif /// ILLIXR_INTEGRATION
+			img0 = cv::Mat{imu_cam_buffer->img0.value()};
+			img1 = cv::Mat{imu_cam_buffer->img1.value()};
 		}
 		double buffer_timestamp_seconds = double(imu_cam_buffer->dataset_time) / NANO_SEC;
 		{
+#ifdef ILLIXR_INTEGRATION
 			CPU_TIMER_TIME_BLOCK("feed_measurement_stereo");
+#endif /// ILLIXR_INTEGRATION
 			open_vins_estimator.feed_measurement_stereo(buffer_timestamp_seconds, img0, img1, 0, 1);
 		}
 
@@ -250,7 +257,9 @@ public:
         assert(isfinite(swapped_pos[2]));
 
 		if (open_vins_estimator.initialized()) {
+#ifdef ILLIXR_INTEGRATION
 			CPU_TIMER_TIME_BLOCK("publish");
+#endif /// ILLIXR_INTEGRATION
 
 			if (isUninitialized) {
 				isUninitialized = false;

--- a/ov_msckf/src/slam2.cpp
+++ b/ov_msckf/src/slam2.cpp
@@ -193,6 +193,9 @@ public:
 
 	void feed_imu_cam(switchboard::ptr<const imu_cam_type> datum, std::size_t iteration_no) {
 		// Ensures that slam doesnt start before valid IMU readings come in
+		double timestamp_in_seconds;
+		{
+			CPU_TIMER_TIME_BLOCK("IMU");
 		if (datum == nullptr) {
 			std::cerr << "slam2:feed_imu_cam datum == nullptr\n";
 			abort();
@@ -200,7 +203,7 @@ public:
 
 		// This ensures that every data point is coming in chronological order If youre failing this assert, 
 		// make sure that your data folder matches the name in offline_imu_cam/plugin.cc
-		double timestamp_in_seconds = (double(datum->dataset_time) / NANO_SEC);
+		timestamp_in_seconds = (double(datum->dataset_time) / NANO_SEC);
 		assert(timestamp_in_seconds > previous_timestamp);
 		previous_timestamp = timestamp_in_seconds;
 
@@ -219,7 +222,10 @@ public:
 			imu_cam_buffer = datum;
 			return;
 		}
+		}
 
+		{
+			CPU_TIMER_TIME_BLOCK("cam");
 		cv::Mat img0;
 		cv::Mat img1;
 
@@ -299,6 +305,7 @@ public:
 		// const_cast<imu_cam_type*>(imu_cam_buffer)->img0.reset();
 		// const_cast<imu_cam_type*>(imu_cam_buffer)->img1.reset();
 		imu_cam_buffer = datum;
+		}
 	}
 
 	virtual ~slam2() override {}


### PR DESCRIPTION
Once #3 is merged, the target branch should change (done).

This PR fixes #2 and fixes #4. It's not too much trouble to review them simultaneously.

I elected to use OpenCV `parallel_for_` because it means I wouldn't have to implement my own threadpool, bring in the multithread queue, it responds to the same `cv::setNumThreads`, and its two-level for-loop unifies the single-threaded and mult-threaded cases.

When numthreads is greater than 2, the ranges will be [0, 1] and [1, 2], so one thread will go `for (size_t i = 0; i < 1; ++i)` (aka `i` gets 1, and then terminates).

In many places we have `i == 0 ? img0 : img1`. A slightly better way of doing this would be: `std::array<Img, 2> imgs;` and `imgs[i]`, but this would require changing every usage of these in the rest of OpenVINS, which I considered too burdensome.

The reviewer should:
- Verify that ILLIXR still works with this commit.
- Make sure my code does the same thing the old code does.
- Give their opinion if the `std::array<T, 2>` trick or others are worth it or worth it in specific cases.