### PR TITLE
Rebase remove old illixr metrics

### DIFF
--- a/ov_core/src/track/Grider_FAST.h
+++ b/ov_core/src/track/Grider_FAST.h
@@ -31,11 +31,6 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
-#ifdef ILLIXR_INTEGRATION
-#include "../../../ov_msckf/src/common/cpu_timer.hpp"
-#endif /// ILLIXR_INTEGRATION
-
-
 namespace ov_core {
 
     /**
@@ -96,8 +91,6 @@ namespace ov_core {
             int ct_rows = std::floor(img.rows/size_y);
             std::vector<std::vector<cv::KeyPoint>> collection(ct_cols*ct_rows);
             parallel_for_(cv::Range(0, ct_cols*ct_rows), [&](const cv::Range& range) {
-				// PRINT_RECORD_FOR_THIS_BLOCK("slam2 par_for");
-				// We time this by timing OpenCV's parallel_for_
 
                 for (int r = range.start; r < range.end; r++) {
                     // Calculate what cell xy value we are in

--- a/ov_core/src/track/TrackDescriptor.cpp
+++ b/ov_core/src/track/TrackDescriptor.cpp
@@ -20,10 +20,6 @@
  */
 #include "TrackDescriptor.h"
 
-#ifdef ILLIXR_INTEGRATION
-#include "../../../ov_msckf/src/common/cpu_timer.hpp"
-#endif /// ILLIXR_INTEGRATION
-
 using namespace ov_core;
 
 
@@ -188,9 +184,9 @@ void TrackDescriptor::feed_stereo(double timestamp, cv::Mat &img_leftin, cv::Mat
 
     // Lets match temporally
 #ifdef ILLIXR_INTEGRATION
-    std::thread t_ll = timed_thread("slam2 rob_match l", &TrackDescriptor::robust_match, this, boost::ref(pts_last[cam_id_left]), boost::ref(pts_left_new),
+    std::thread t_ll = std::thread(&TrackDescriptor::robust_match, this, boost::ref(pts_last[cam_id_left]), boost::ref(pts_left_new),
                                        boost::ref(desc_last[cam_id_left]), boost::ref(desc_left_new), cam_id_left, cam_id_left, boost::ref(matches_ll));
-    std::thread t_rr = timed_thread("slam2 rob_match r", &TrackDescriptor::robust_match, this, boost::ref(pts_last[cam_id_right]), boost::ref(pts_right_new),
+    std::thread t_rr = std::thread(&TrackDescriptor::robust_match, this, boost::ref(pts_last[cam_id_right]), boost::ref(pts_right_new),
                                        boost::ref(desc_last[cam_id_right]), boost::ref(desc_right_new), cam_id_right, cam_id_right, boost::ref(matches_rr));
 #else /// ILLIXR_INTEGRATION
     boost::thread t_ll = boost::thread(&TrackDescriptor::robust_match, this, boost::ref(pts_last[cam_id_left]), boost::ref(pts_left_new),
@@ -352,9 +348,9 @@ void TrackDescriptor::perform_detection_stereo(const cv::Mat &img0, const cv::Ma
     // Extract our features (use FAST with griding)
     std::vector<cv::KeyPoint> pts0_ext, pts1_ext;
 #ifdef ILLIXR_INTEGRATION
-    std::thread t_0 = timed_thread("slam2 grid l", &Grider_FAST::perform_griding, boost::cref(img0), boost::ref(pts0_ext),
+    std::thread t_0 = std::thread(&Grider_FAST::perform_griding, boost::cref(img0), boost::ref(pts0_ext),
                                       num_features, grid_x, grid_y, threshold, true);
-    std::thread t_1 = timed_thread("slam2 grid r", &Grider_FAST::perform_griding, boost::cref(img1), boost::ref(pts1_ext),
+    std::thread t_1 = std::thread(&Grider_FAST::perform_griding, boost::cref(img1), boost::ref(pts1_ext),
                                       num_features, grid_x, grid_y, threshold, true);
 #else /// ILLIXR_INTEGRATION
     boost::thread t_0 = boost::thread(&Grider_FAST::perform_griding, boost::cref(img0), boost::ref(pts0_ext),
@@ -372,8 +368,8 @@ void TrackDescriptor::perform_detection_stereo(const cv::Mat &img0, const cv::Ma
 
     // Use C++11 lamdas so we can pass all theses variables by reference
 #ifdef ILLIXR_INTEGRATION
-    std::thread t_desc0 = timed_thread("slam2 orb l", [&]{this->orb0->compute(img0, pts0_ext, desc0_ext);});
-    std::thread t_desc1 = timed_thread("slam2 orb r", [&]{this->orb1->compute(img1, pts1_ext, desc1_ext);});
+    std::thread t_desc0 = std::thread([&]{this->orb0->compute(img0, pts0_ext, desc0_ext);});
+    std::thread t_desc1 = std::thread([&]{this->orb1->compute(img1, pts1_ext, desc1_ext);});
 #else /// ILLIXR_INTEGRATION
     std::thread t_desc0 = std::thread([this,&img0,&pts0_ext,&desc0_ext]{this->orb0->compute(img0, pts0_ext, desc0_ext);});
     std::thread t_desc1 = std::thread([this,&img1,&pts1_ext,&desc1_ext]{this->orb1->compute(img1, pts1_ext, desc1_ext);});

--- a/ov_msckf/src/core/VioManager.cpp
+++ b/ov_msckf/src/core/VioManager.cpp
@@ -23,10 +23,6 @@
 
 #include "utils/parse_cmd.h"
 
-#ifdef ILLIXR_INTEGRATION
-#include "../common/cpu_timer.hpp"
-#endif /// ILLIXR_INTEGRATION
-
 using namespace ov_core;
 using namespace ov_type;
 using namespace ov_msckf;
@@ -186,8 +182,8 @@ void VioManager::feed_measurement_stereo(double timestamp, cv::Mat& img0, cv::Ma
         trackFEATS->feed_stereo(timestamp, img0, img1, cam_id0, cam_id1);
     } else {
 #ifdef ILLIXR_INTEGRATION
-        std::thread t_l = timed_thread("slam2 feed l", &TrackBase::feed_monocular, trackFEATS, boost::ref(timestamp), boost::ref(img0), boost::ref(cam_id0));
-        std::thread t_r = timed_thread("slam2 feed r", &TrackBase::feed_monocular, trackFEATS, boost::ref(timestamp), boost::ref(img1), boost::ref(cam_id1));
+        std::thread t_l = std::thread(&TrackBase::feed_monocular, trackFEATS, boost::ref(timestamp), boost::ref(img0), boost::ref(cam_id0));
+        std::thread t_r = std::thread(&TrackBase::feed_monocular, trackFEATS, boost::ref(timestamp), boost::ref(img1), boost::ref(cam_id1));
 #else /// ILLIXR_INTEGRATION
         boost::thread t_l = boost::thread(&TrackBase::feed_monocular, trackFEATS, boost::ref(timestamp), boost::ref(img0), boost::ref(cam_id0));
         boost::thread t_r = boost::thread(&TrackBase::feed_monocular, trackFEATS, boost::ref(timestamp), boost::ref(img1), boost::ref(cam_id1));


### PR DESCRIPTION
Rebase. Closes #21.

This is a fast forward step since redo timing is not yet to merge. But I noticed that spdlog is also trying to use this branch, and the changes are not hurting anything else, so we can merge this now and include it in a new tag.